### PR TITLE
fix: change default shell for GH actions to have a TTY

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,6 +3,12 @@ name: build-release
 on:
   push:
     branches: [main]
+
+defaults:
+  run:
+    # GitHub Actions run without a TTY device. This is a workaround to get one,
+    # based on https://github.com/actions/runner/issues/241#issuecomment-2019042651
+    shell: 'script --return --quiet --log-out /dev/null --command "bash -e {0}"'
     
 jobs:
   build-release:


### PR DESCRIPTION
the dockerized golang build still requires a TTY for some reason